### PR TITLE
食材の在庫を表示できるようにテーブル機能を変更

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -34,6 +34,7 @@ class HomeController extends Controller
         ->whereNull('deleted_at')
         ->orderby('created_at','DESC')
         ->get();
+
         //在庫数を取得
         // $stocks= Stock::select('stock.*')
         // ->where('food_id' , '=' , \Food::id())

--- a/database/migrations/2022_12_19_153254_create_food_table.php
+++ b/database/migrations/2022_12_19_153254_create_food_table.php
@@ -17,6 +17,7 @@ class CreateFoodTable extends Migration
             $table->unsignedBigInteger('id',true);
             $table->unsignedBigInteger('user_id');
             $table->string('name');
+            $table->unsignedBigInteger('stock');
             $table->softDeletes();
             $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
             $table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -12,7 +12,7 @@
                 </a>
                 <a href="">
                     <p>
-                        在庫数
+                        {{ $food['stock']}}
                     </p>
                 </a>
             </div>


### PR DESCRIPTION
在庫数を表示させるために、DB設計を修正し、stockのテーブルをfoodに追加した。
そしてそのデータを食材ページで表示することによって食材とその在庫数を同ページ内で把握できるようにデザインした。